### PR TITLE
Pseudo restore Voice Recognition Unit capabilities

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libultraship"]
 	path = libultraship
-	url = https://github.com/kenix3/libultraship.git
+	url = https://github.com/balloondude2/libultraship.git
 [submodule "OTRExporter"]
 	path = OTRExporter
 	url = https://github.com/louist103/OTRExporter.git

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # 2 Ship 2 Harkinian
 
+This is an outdated branch.
+
 ## Discord
 
 Official Discord: https://discord.com/invite/shipofharkinian

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -50,6 +50,7 @@ typedef enum {
     DISABLE_FOR_FRAME_ADVANCE_OFF,
     DISABLE_FOR_WARP_POINT_NOT_SET,
     DISABLE_FOR_INTRO_SKIP_OFF,
+    DISABLE_FOR_VOICE_OFF,
 } DisableOption;
 
 struct widgetInfo;
@@ -348,7 +349,12 @@ static std::map<DisableOption, disabledInfo> disabledMap = {
         "Warp Point Not Saved" } },
     { DISABLE_FOR_INTRO_SKIP_OFF,
       { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Cutscenes.SkipIntroSequence", 0); },
-        "Intro Skip Not Selected" } }
+        "Intro Skip Not Selected" } },
+    { DISABLE_FOR_VOICE_OFF,
+      { [](disabledInfo& info) -> bool {
+           return !CVarGetInteger("gEnhancements.Restorations.VoiceRecognitionUnit", 0);
+       },
+        "Voice Recognition Unit is Disabled" } }
 };
 
 std::unordered_map<int32_t, const char*> menuThemeOptions = {
@@ -431,6 +437,12 @@ static const std::unordered_map<int32_t, const char*> dekuGuardSearchBallsOption
     { DEKU_GUARD_SEARCH_BALLS_NEVER, "Never" },
     { DEKU_GUARD_SEARCH_BALLS_NIGHT_ONLY, "Night Only" },
     { DEKU_GUARD_SEARCH_BALLS_ALWAYS, "Always" },
+};
+
+static const std::unordered_map<int32_t, const char*> voiceWordOptions = {
+    { VOICE_WORD_NONE, "None" },    { VOICE_WORD_TIME, "ato nan jikan" }, { VOICE_WORD_PICTURE, "hai chi-zu" },
+    { VOICE_WORD_WAKE, "okiro-" },  { VOICE_WORD_SIT, "osuwari" },        { VOICE_WORD_MILK, "miruku" },
+    { VOICE_WORD_EPONA, "haiya-" },
 };
 
 void FreeLookPitchMinMax() {
@@ -1391,6 +1403,22 @@ void AddEnhancements() {
                 WIDGET_CVAR_CHECKBOX },
               { "Tatl ISG", "gEnhancements.Restorations.TatlISG", "Restores Navi ISG from OoT, but now with Tatl.",
                 WIDGET_CVAR_CHECKBOX },
+              { "Voice Recognition Unit", "gEnhancements.Restorations.VoiceRecognitionUnit",
+                "Enables VRU functionality.", WIDGET_CVAR_CHECKBOX },
+              { "VRU Word Selection",
+                "gEnhancements.Restorations.VoiceRecognitionUnitWord",
+                "Choose what word to 'say' when L is pressed.\n"
+                "- None: No word\n"
+                "- ato nan jikan: What time is it? Ask Sheikah Stones.\n"
+                "- hai chi-zu: Say Cheese. Take a picture.\n"
+                "- okiro-: Wake up. Wake up a sleepy scrub.\n"
+                "- osuwari: Sit. Does not appear to do anything.\n"
+                "- miruku: Milk. Ask a cow nicely for two portions of milk.\n"
+                "- Haiya-: Spur Epona.",
+                WIDGET_CVAR_COMBOBOX,
+                { .defaultVariant = VOICE_WORD_NONE, .comboBoxOptions = voiceWordOptions },
+                nullptr,
+                [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_VOICE_OFF).active; } },
               { "Woodfall Mountain Appearance", "gEnhancements.Restorations.WoodfallMountainAppearance",
                 "Restores the appearance of Woodfall mountain to not look poisoned "
                 "when viewed from Termina Field after clearing Woodfall Temple\n\n"

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -34,6 +34,16 @@ enum DekuGuardSearchBallsOptions {
     DEKU_GUARD_SEARCH_BALLS_ALWAYS,
 };
 
+enum VoiceWordOptions {
+    VOICE_WORD_TIME,
+    VOICE_WORD_PICTURE,
+    VOICE_WORD_WAKE,
+    VOICE_WORD_SIT,
+    VOICE_WORD_MILK,
+    VOICE_WORD_EPONA,
+    VOICE_WORD_NONE = 0xFFFF,
+};
+
 // Old Entry Point
 void InitEnhancements();
 

--- a/mm/2s2h/Enhancements/Restorations/VoiceRecognitionUnit.cpp
+++ b/mm/2s2h/Enhancements/Restorations/VoiceRecognitionUnit.cpp
@@ -1,0 +1,106 @@
+#include <libultraship/libultraship.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "Enhancements/Enhancements.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+OSMesgQueue* PadMgr_AcquireSerialEventQueue(void);
+void PadMgr_ReleaseSerialEventQueue(OSMesgQueue* serialEventQueue);
+PlayState* gPlayState;
+#include "z64voice.h"
+#include "macros.h"
+// void func_801A4EB0(void); // orignial function, nops
+void func_801A4EB8(void);
+}
+
+#define CVAR_NAME "gEnhancements.Restorations.VoiceRecognitionUnit"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define CVAR_NAME_WORD "gEnhancements.Restorations.VoiceRecognitionUnitWord"
+#define CVAR_WORD CVarGetInteger(CVAR_NAME_WORD, VOICE_WORD_NONE)
+
+// Implementations of VRU functions
+int32_t osVoiceInit(OSMesgQueue* mq, OSVoiceHandle* hd, int channel) {
+    LUSLOG_DEBUG("osVoiceInit, channel: %x", channel);
+    return 0;
+}
+
+int32_t osVoiceSetWord(OSVoiceHandle* hd, u8* word) {
+    // LUSLOG_DEBUG("osVoiceSetWord", NULL);
+    return 0;
+}
+int32_t osVoiceCheckWord(u8* word) {
+    // LUSLOG_DEBUG("osVoiceCheckWord", NULL);
+    return 0;
+}
+int32_t osVoiceStartReadData(OSVoiceHandle* hd) {
+    // LUSLOG_DEBUG("osVoiceStartReadData", NULL);
+    return 0;
+}
+int32_t osVoiceStopReadData(OSVoiceHandle* hd) {
+    // LUSLOG_DEBUG("osVoiceStopReadData", NULL);
+    return 0;
+}
+int32_t osVoiceGetReadData(OSVoiceHandle* hd, OSVoiceData* result) {
+    // LUSLOG_DEBUG("osVoiceGetReadData", NULL);
+
+    result->answer[0] = VOICE_WORD_ID_NONE;
+
+    if (gPlayState == nullptr or !CVAR) {
+        return 0;
+    }
+
+    if (CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
+        result->warning = 0;
+        result->answerNum = 1;
+        result->voiceLevel = 1000;
+        result->voiceRelLevel = 2500;
+        result->answer[0] = CVAR_WORD;
+        result->distance[0] = 10;
+    }
+
+    return 0;
+}
+int32_t osVoiceClearDictionary(OSVoiceHandle* hd, u8 numWords) {
+    // LUSLOG_DEBUG("osVoiceClearDictionary", NULL);
+    return 0;
+}
+int32_t osVoiceMaskDictionary(OSVoiceHandle* hd, u8* maskPattern, int size) {
+    // LUSLOG_DEBUG("osVoiceMaskDictionary", NULL);
+    return 0;
+}
+int32_t osVoiceControlGain(OSVoiceHandle* hd, s32 analog, s32 digital) {
+    // LUSLOG_DEBUG("osVoiceControlGain", NULL);
+    return 0;
+}
+
+void RegisterVoiceRecognitionUnit() {
+    LUSLOG_DEBUG("Register Voice", 0);
+    if (CVAR) {
+        s32 i = 3;
+        OSMesgQueue* serialEventQueue;
+        s32 ret;
+
+        serialEventQueue = PadMgr_AcquireSerialEventQueue();
+
+        ret = osVoiceInit(serialEventQueue, &gVoiceHandle, i);
+
+        PadMgr_ReleaseSerialEventQueue(serialEventQueue);
+
+        if (ret != 0) {
+            // error
+        } else {
+            // sVoiceInitStatus = VOICE_INIT_SUCCESS;
+            // func_801A4EB0();
+            func_801A4EB8();
+        }
+
+        // If sVoiceInitStatus is still VOICE_INIT_TRY after the first attempt to initialize a VRU, don't try again
+        // if (sVoiceInitStatus == VOICE_INIT_TRY) {
+        //     sVoiceInitStatus = VOICE_INIT_FAILED;
+        // }
+    }
+
+    // TODO: Get out of the voice loop when unchecked
+}
+
+static RegisterShipInitFunc initFunc(RegisterVoiceRecognitionUnit, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Restorations/VoiceRecognitionUnit.cpp
+++ b/mm/2s2h/Enhancements/Restorations/VoiceRecognitionUnit.cpp
@@ -9,7 +9,6 @@ void PadMgr_ReleaseSerialEventQueue(OSMesgQueue* serialEventQueue);
 PlayState* gPlayState;
 #include "z64voice.h"
 #include "macros.h"
-// void func_801A4EB0(void); // orignial function, nops
 void func_801A4EB8(void);
 }
 
@@ -18,30 +17,28 @@ void func_801A4EB8(void);
 #define CVAR_NAME_WORD "gEnhancements.Restorations.VoiceRecognitionUnitWord"
 #define CVAR_WORD CVarGetInteger(CVAR_NAME_WORD, VOICE_WORD_NONE)
 
-// Implementations of VRU functions
+// Implementation of VRU functions
 int32_t osVoiceInit(OSMesgQueue* mq, OSVoiceHandle* hd, int channel) {
-    LUSLOG_DEBUG("osVoiceInit, channel: %x", channel);
     return 0;
 }
 
 int32_t osVoiceSetWord(OSVoiceHandle* hd, u8* word) {
-    // LUSLOG_DEBUG("osVoiceSetWord", NULL);
     return 0;
 }
+
 int32_t osVoiceCheckWord(u8* word) {
-    // LUSLOG_DEBUG("osVoiceCheckWord", NULL);
     return 0;
 }
+
 int32_t osVoiceStartReadData(OSVoiceHandle* hd) {
-    // LUSLOG_DEBUG("osVoiceStartReadData", NULL);
     return 0;
 }
+
 int32_t osVoiceStopReadData(OSVoiceHandle* hd) {
-    // LUSLOG_DEBUG("osVoiceStopReadData", NULL);
     return 0;
 }
+
 int32_t osVoiceGetReadData(OSVoiceHandle* hd, OSVoiceData* result) {
-    // LUSLOG_DEBUG("osVoiceGetReadData", NULL);
 
     result->answer[0] = VOICE_WORD_ID_NONE;
 
@@ -50,57 +47,36 @@ int32_t osVoiceGetReadData(OSVoiceHandle* hd, OSVoiceData* result) {
     }
 
     if (CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
+        // These values arbitrarily chosen to meet thresholds required in voice_internal.c
         result->warning = 0;
         result->answerNum = 1;
         result->voiceLevel = 1000;
         result->voiceRelLevel = 2500;
-        result->answer[0] = CVAR_WORD;
         result->distance[0] = 10;
+
+        result->answer[0] = CVAR_WORD;
     }
 
     return 0;
 }
+
 int32_t osVoiceClearDictionary(OSVoiceHandle* hd, u8 numWords) {
-    // LUSLOG_DEBUG("osVoiceClearDictionary", NULL);
     return 0;
 }
+
 int32_t osVoiceMaskDictionary(OSVoiceHandle* hd, u8* maskPattern, int size) {
-    // LUSLOG_DEBUG("osVoiceMaskDictionary", NULL);
     return 0;
 }
+
 int32_t osVoiceControlGain(OSVoiceHandle* hd, s32 analog, s32 digital) {
-    // LUSLOG_DEBUG("osVoiceControlGain", NULL);
     return 0;
 }
 
 void RegisterVoiceRecognitionUnit() {
-    LUSLOG_DEBUG("Register Voice", 0);
     if (CVAR) {
-        s32 i = 3;
-        OSMesgQueue* serialEventQueue;
-        s32 ret;
-
-        serialEventQueue = PadMgr_AcquireSerialEventQueue();
-
-        ret = osVoiceInit(serialEventQueue, &gVoiceHandle, i);
-
-        PadMgr_ReleaseSerialEventQueue(serialEventQueue);
-
-        if (ret != 0) {
-            // error
-        } else {
-            // sVoiceInitStatus = VOICE_INIT_SUCCESS;
-            // func_801A4EB0();
-            func_801A4EB8();
-        }
-
-        // If sVoiceInitStatus is still VOICE_INIT_TRY after the first attempt to initialize a VRU, don't try again
-        // if (sVoiceInitStatus == VOICE_INIT_TRY) {
-        //     sVoiceInitStatus = VOICE_INIT_FAILED;
-        // }
+        // Start the VRU loop
+        func_801A4EB8();
     }
-
-    // TODO: Get out of the voice loop when unchecked
 }
 
 static RegisterShipInitFunc initFunc(RegisterVoiceRecognitionUnit, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Restorations/VoiceRecognitionUnit.cpp
+++ b/mm/2s2h/Enhancements/Restorations/VoiceRecognitionUnit.cpp
@@ -6,9 +6,10 @@
 extern "C" {
 OSMesgQueue* PadMgr_AcquireSerialEventQueue(void);
 void PadMgr_ReleaseSerialEventQueue(OSMesgQueue* serialEventQueue);
-PlayState* gPlayState;
+// PlayState* gPlayState;
+
+#include "variables.h"
 #include "z64voice.h"
-#include "macros.h"
 void func_801A4EB8(void);
 }
 

--- a/mm/include/PR/os_voice.h
+++ b/mm/include/PR/os_voice.h
@@ -1,6 +1,7 @@
 #ifndef PR_OS_VOICE_H
 #define PR_OS_VOICE_H
-
+#include <libultraship/libultra/voice.h>
+#if 0
 #include "ultratypes.h"
 #include "os_message.h"
 
@@ -66,4 +67,5 @@ s32 osVoiceClearDictionary(OSVoiceHandle* hd, u8 numWords);
 s32 osVoiceMaskDictionary(OSVoiceHandle* hd, u8* maskPattern, int size);
 s32 osVoiceControlGain(OSVoiceHandle* hd, s32 analog, s32 digital);
 
+#endif
 #endif

--- a/mm/src/audio/voice_external.c
+++ b/mm/src/audio/voice_external.c
@@ -36,7 +36,6 @@ void func_801A4EB0(void) {
 }
 
 void func_801A4EB8(void) {
-#if 0
     u8* new_var;
     OSMesgQueue* serialEventQueue;
     s32 index;
@@ -66,12 +65,10 @@ void func_801A4EB8(void) {
         func_801A53E8(800, 2, VOICE_WARN_TOO_SMALL, 500, 2000);
         D_801D8E3C = 1;
     }
-#endif
 }
 
 // Used externally in code_8019AF00
 void func_801A4FD8(void) {
-#if 0
     s32 errorCode;
     OSMesgQueue* serialEventQueue;
 
@@ -91,7 +88,6 @@ void func_801A4FD8(void) {
         func_801A5080(VOICE_WORD_ID_HIYA);
         func_801A5080(VOICE_WORD_ID_CHEESE);
     }
-#endif
 }
 
 void func_801A5080(u16 wordId) {

--- a/mm/src/audio/voice_internal.c
+++ b/mm/src/audio/voice_internal.c
@@ -58,8 +58,6 @@ s32 func_801A51F0(s32 errorCode) {
 }
 
 s32 func_801A5228(OSVoiceDictionary* dict) {
-    return 0;
-#if 0
     OSMesgQueue* serialEventQueue;
     s32 errorCode;
     u8 numWords;
@@ -97,12 +95,9 @@ s32 func_801A5228(OSVoiceDictionary* dict) {
     }
 
     return errorCode;
-#endif
 }
 
 OSVoiceData* func_801A5390(void) {
-    return NULL;
-#if 0
     OSVoiceData* voiceData;
     OSMesgQueue* serialEventQueue;
 
@@ -114,7 +109,6 @@ OSVoiceData* func_801A5390(void) {
     PadMgr_VoiceReleaseSerialEventQueue(serialEventQueue);
 
     return voiceData;
-#endif
 }
 
 // Unused
@@ -133,7 +127,6 @@ void func_801A53E8(u16 distance, u16 answerNum, u16 warning, u16 voiceLevel, u16
 // Unused
 // Could have a return? or be void return?
 s32 func_801A541C(s32 analog, s32 digital) {
-#if 0
     s32 errorCode;
     OSMesgQueue* serialEventQueue;
 
@@ -146,13 +139,10 @@ s32 func_801A541C(s32 analog, s32 digital) {
             func_801A51F0(errorCode);
         }
     }
-#endif
 }
 
 // Unused
 s32 func_801A5488(u8* word) {
-    return 0;
-#if 0
     s32 errorCode;
     OSMesgQueue* serialEventQueue;
 
@@ -161,7 +151,6 @@ s32 func_801A5488(u8* word) {
     PadMgr_VoiceReleaseSerialEventQueue(serialEventQueue);
 
     return errorCode;
-#endif
 }
 
 u8* func_801A54C4(void) {
@@ -169,8 +158,6 @@ u8* func_801A54C4(void) {
 }
 
 s32 func_801A54D0(u16 wordId) {
-    return 0;
-#if 0
     s32 errorCode;
     u8 phi_t0 = true;
     u8 numWords;
@@ -211,12 +198,9 @@ s32 func_801A54D0(u16 wordId) {
     }
 
     return errorCode;
-#endif
 }
 
 s32 func_801A5680(u16 wordId) {
-    return 0;
-#if 0
     s32 errorCode;
     u8 phi_a3 = true;
     u8 numWords;
@@ -257,12 +241,9 @@ s32 func_801A5680(u16 wordId) {
     }
 
     return errorCode;
-#endif
 }
 
 s32 func_801A5808(void) {
-    return 0;
-#if 0
     s32 errorCode = 0;
     s32 ret;
     OSMesgQueue* serialEventQueue;
@@ -331,7 +312,6 @@ s32 func_801A5808(void) {
     ret = func_801A51F0(errorCode);
 
     return ret;
-#endif
 }
 
 // Unused

--- a/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
+++ b/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
@@ -702,7 +702,7 @@ void EnDg_IdleMove(EnDg* this, PlayState* play) {
             EnDg_ChangeAnim(&this->skelAnime, sAnimationInfo, DOG_ANIM_SIT_DOWN_ONCE);
             this->timer = 30;
             this->actionFunc = EnDg_SitOnce;
-        } 
+        }
     }
 }
 

--- a/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
+++ b/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
@@ -6,6 +6,7 @@
 
 #include "z_en_dg.h"
 #include "overlays/actors/ovl_En_Aob_01/z_en_aob_01.h"
+#include "z64voice.h"
 
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_10 | ACTOR_FLAG_800000)
 
@@ -37,6 +38,7 @@ void EnDg_Held(EnDg* this, PlayState* play);
 void EnDg_Thrown(EnDg* this, PlayState* play);
 void EnDg_SetupTalk(EnDg* this, PlayState* play);
 void EnDg_Talk(EnDg* this, PlayState* play);
+void EnDg_SitOnce(EnDg* this, PlayState* play);
 
 ActorInit En_Dg_InitVars = {
     /**/ ACTOR_EN_DG,
@@ -693,7 +695,35 @@ void EnDg_IdleMove(EnDg* this, PlayState* play) {
         EnDg_ChangeAnim(&this->skelAnime, sAnimationInfo, DOG_ANIM_BARK);
         this->actionFunc = EnDg_IdleBark;
     }
+
+    // voiceRegion
+    if (this->actor.xzDistToPlayer < 150.0f) {
+        if (AudioVoice_GetWord() == VOICE_WORD_ID_SIT) {
+            EnDg_ChangeAnim(&this->skelAnime, sAnimationInfo, DOG_ANIM_SIT_DOWN_ONCE);
+            this->timer = 30;
+            this->actionFunc = EnDg_SitOnce;
+        } 
+    }
 }
+
+void EnDg_SitOnce(EnDg* this, PlayState* play) {
+    Player* player = GET_PLAYER(play);
+
+    if (!(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
+        this->actionFunc = EnDg_Fall;
+    }
+
+    if (this->actor.xzDistToPlayer < 50.0f) {
+        Math_ApproachS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 4, 0xC00);
+        this->actor.world.rot.y = this->actor.shape.rot.y;
+    }
+
+    if (DECR(this->timer) == 0) {
+        this->timer = Rand_S16Offset(60, 60);
+        EnDg_SetupIdleMove(this, play);
+    }
+}
+// endregion
 
 /**
  * Stops and barks, before returning to moving along its path.


### PR DESCRIPTION
This build "restores" the Voice Recognition commands that were left in Majora's Mask. I was having difficulties adding an actual Voice Recognition library, so I decided to provide a drop-down list of the possible words that could then be "spoken" by pressing the L-button. 

The Voice Recognition can be turned on by going to Enhancements > Restorations > Voice Recognition Unit in the Searchable Menu (Esc). It is not implemented in the old Menu Bar. 

The words left in the game are: 

- Ato nan jikan | How many hours are left. Used when Z-targeting a Gossip Stone
- Hai chi-zu | Say Cheese. Used to take a pictobox picture
- Okiro- | Wake up. Used to wake up the sleeping scrub in the Swamp Spider House
- Osuwari | Sit. Isn't originally used. I added something in. Try it near dogs.
- Miruku | Milk. Used to get milk from cows
- Haiya- | Hiya. Used to spur Epona



https://github.com/user-attachments/assets/9ea6cc56-5013-4459-823a-020c3c034548



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/balloondude2/2ship2harkinian/actions/artifacts/2368786770.zip)
  - [2ship-linux.zip](https://nightly.link/balloondude2/2ship2harkinian/actions/artifacts/2368787128.zip)
  - [2ship-windows.zip](https://nightly.link/balloondude2/2ship2harkinian/actions/artifacts/2368790226.zip)
<!--- section:artifacts:end -->